### PR TITLE
Fix infinite loop by updating endpoint and removing persistent params

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class PublicPrograms:
         Returns:
             List[dict]: A list of dictionaries representing public programs.
         """
-        endpoint = f'{self.api.base_url}/v1/hackers/programs'
+        endpoint = f'{self.api.base_url}/v1/hackers/programs?page[size]=100'
         response_json = self.api.paginate(endpoint)
 
         for response in response_json:

--- a/platforms/hackerone.py
+++ b/platforms/hackerone.py
@@ -30,12 +30,9 @@ class HackerOneAPI(API):
             List[dict]: A list of dictionaries representing the response JSON for each page.
         """
         results = []
-        params = {
-            'page[size]': 100
-        }
 
         while True:
-            response_json = self.get(endpoint, params=params)
+            response_json = self.get(endpoint)
             results.append(response_json)
 
             if 'next' in response_json['links']:


### PR DESCRIPTION
## Summary

This PR fixes an issue that caused the script to get stuck in an infinite loop when crawling paginated data from HackerOne.

## Changes Made

- Updated the `endpoint` value in `main.py` to ensure the correct API parameters is used.
- Removed the `params` array from `platform/hackerone.py` because reusing the same params for each request prevented the pagination from progressing. The next URL is already included in the response JSON, and does not require the original parameters.

## Why

When the original `params` were reused in every iteration, the next URL (fetched from the response) would not work as expected. This caused the loop to always return the same result, effectively freezing the process.

This change allows the crawler to follow the correct next URL without interference, fixing the infinite loop issue.

---

Let me know if you'd like me to improve or test anything further.
